### PR TITLE
feat: use shared data infrastructure dev network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,4 +26,5 @@ services:
 
 networks:
   default:
-    name: data-infrastructure-shared-network
+    external:
+      name: data-infrastructure-shared-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,7 @@ services:
     restart: always
     ports:
       - "6370:6379"
+
+networks:
+  default:
+    name: data-infrastructure-shared-network


### PR DESCRIPTION
Used a single network for all Data Infrastructure apps/services so that
they can be linked together more easily when working locally, e.g. to
connect data-flow and data-store-service.